### PR TITLE
fix: exact version match + gate delete on absent only (#50 items 2a/3/4)

### DIFF
--- a/tasks/all-tasks.yaml
+++ b/tasks/all-tasks.yaml
@@ -28,7 +28,12 @@
 
 - name: Include tasks for deleting binarys
   ansible.builtin.include_tasks: delete-binary.yaml
-  when: is_in_bin_dir and ( wanted_state =="absent" ) or checksum_wrong|bool or ( (versions_match is not defined) or (not versions_match) )
+  # Only remove a binary we manage when it should be absent. Reinstall
+  # (checksum/version mismatch) needs no pre-delete: download-copy-binary
+  # overwrites with force: true — and pre-deleting install_path was the step
+  # that crashed on the /usr/bin/yq file path. (Previously the `and`/`or`
+  # precedence meant is_in_bin_dir only guarded the `absent` branch anyway.)
+  when: wanted_state == "absent" and is_in_bin_dir
 
 - name: Include download tasks
   ansible.builtin.include_tasks: download-copy-binary.yaml

--- a/tasks/check-binary-version.yaml
+++ b/tasks/check-binary-version.yaml
@@ -8,5 +8,10 @@
   
 - name: Compare installed version and wanted version
   ansible.builtin.set_fact:
-    versions_match: "{{ item.value.bin_version in result_c.stdout }}"
+    # Contract: `<bin_name> <version_cmd>` must print the installed version
+    # somewhere in stdout (e.g. "... version v4.49.2"). Match bin_version as a
+    # whole version token, not a bare substring: the digit/dot lookarounds stop
+    # "1.2" from matching "1.2.3" or "11.2". regex_escape neutralises the dots.
+    versions_match: >-
+      {{ result_c.stdout is search('(?<![0-9.])' ~ (item.value.bin_version | regex_escape) ~ '(?![0-9.])') }}
   when: item.value.version_cmd is defined


### PR DESCRIPTION
Addresses #50 items **2a**, **3**, **4**.

- **2a** `check-binary-version`: compare `bin_version` as a whole version token via an anchored regex (digit/dot lookarounds + `regex_escape`) instead of a bare substring, so `1.2` no longer matches `1.2.3`/`11.2`. Documents the `version_cmd` output contract.
- **3 + 4** `all-tasks`: gate `delete-binary` on `wanted_state == "absent" and is_in_bin_dir`. Reinstall (checksum/version mismatch) needs no pre-delete — `download-copy-binary` overwrites with `force: true` — and pre-deleting `install_path` was the step that crashed on the `/usr/bin/yq` file path. Removes the ambiguous `and`/`or` precedence where `is_in_bin_dir` only guarded the `absent` branch.

Regex validated against yq/kubectl/kind/helm real outputs + the `1.2`-in-`1.2.3`/`11.2` traps. Item 5 (molecule full-file-path/pre-existing-binary case) still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)