### PR TITLE
test(molecule): cover full-file-path convention + pre-existing binary (#50 item 5)

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -71,6 +71,21 @@
         version_cmd: " version --short"
         target_version: v0.32.4
         #md5_checksum: "04ba6f524a433f8ceb9095c4c8292240"
+      # Full-file-path convention: bin_to_copy basename (yq_linux_amd64) differs
+      # from bin_name (yq), so bin_dir is the full target FILE path and the copy
+      # renames the artifact to `yq`. prepare.yml pre-seeds /usr/bin/yq as a stale
+      # file so this exercises install over an existing file (the /usr/bin/yq/yq
+      # crash scenario) + the anchored version check.
+      yq:
+        bin_name: "yq"
+        bin_version: "v4.44.1"
+        check_bin_version_before_installing: true
+        source_url: "https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64.tar.gz"
+        bin_to_copy: "yq_linux_amd64"
+        to_remove: ""
+        bin_dir: "/usr/bin/yq"
+        version_cmd: " --version"
+        target_version: v4.44.1
 
   pre_tasks:
     - name: Update apt cache

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -38,3 +38,4 @@ scenario:
     - create
     - prepare
     - converge
+    - verify

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,19 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  become_method: sudo
+  tasks:
+    # Fixture for the full-file-path convention (yq/kind): seed a pre-existing
+    # `yq` as a plain FILE at the exact bin_dir target. This is the condition
+    # that reproduced the original `/usr/bin/yq/yq` "[Errno 20] Not a directory"
+    # crash — the role must treat bin_dir as an existing file, not a directory,
+    # and reinstall over it. The stale version also forces the version-check /
+    # reinstall path to run.
+    - name: Seed a stale /usr/bin/yq binary (wrong version)
+      ansible.builtin.copy:
+        content: |
+          #!/bin/sh
+          echo "yq (stale seed) version v0.0.0"
+        dest: /usr/bin/yq
+        mode: "0755"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,62 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+  become_method: sudo
+  tasks:
+    # --- Full-file-path convention (yq) ---------------------------------------
+    - name: Stat the full-file-path target /usr/bin/yq
+      ansible.builtin.stat:
+        path: /usr/bin/yq
+      register: yq_stat
+
+    - name: /usr/bin/yq must be a regular file, not a directory
+      ansible.builtin.assert:
+        that:
+          - yq_stat.stat.exists
+          - yq_stat.stat.isreg
+          - not yq_stat.stat.isdir
+        fail_msg: "/usr/bin/yq should be a regular file (full-file-path convention)"
+        success_msg: "/usr/bin/yq is a regular file"
+
+    # `stat` on /usr/bin/yq/yq raises ENOTDIR (bin_dir is a file), so probe with
+    # `test -e`, which just returns non-zero for the non-existent nested path.
+    - name: Probe the malformed nested path /usr/bin/yq/yq
+      ansible.builtin.command: test -e /usr/bin/yq/yq
+      register: yq_nested
+      changed_when: false
+      failed_when: false
+
+    - name: The malformed /usr/bin/yq/yq path must never be created
+      ansible.builtin.assert:
+        that:
+          - yq_nested.rc != 0
+        fail_msg: "/usr/bin/yq/yq exists — install_path regressed"
+        success_msg: "no /usr/bin/yq/yq — install_path resolves correctly"
+
+    - name: Run yq --version
+      ansible.builtin.command: yq --version
+      register: yq_ver
+      changed_when: false
+
+    - name: yq was reinstalled over the stale seed at the wanted version
+      ansible.builtin.assert:
+        that:
+          - "'v4.44.1' in yq_ver.stdout"
+          - "'v0.0.0' not in yq_ver.stdout"
+        fail_msg: "yq not reinstalled over the stale /usr/bin/yq seed: {{ yq_ver.stdout }}"
+        success_msg: "yq reinstalled over the stale seed: {{ yq_ver.stdout }}"
+
+    # --- Directory convention still works (regression guard) ------------------
+    - name: Stat a directory-convention binary (velero at bin_dir/bin_name)
+      ansible.builtin.stat:
+        path: /usr/local/bin/velero
+      register: velero_stat
+
+    - name: velero installed at /usr/local/bin/velero
+      ansible.builtin.assert:
+        that:
+          - velero_stat.stat.exists
+          - velero_stat.stat.isreg
+        fail_msg: "velero missing — directory convention regressed"
+        success_msg: "velero installed (directory convention intact)"


### PR DESCRIPTION
Closes the last open item of #50 (**item 5**, test gap).

Every existing molecule `bin` used the directory convention (`bin_dir=/usr/local/bin`, `basename == bin_name`), so the **full-file-path convention** (yq/kind: `basename != bin_name`, `bin_dir` is the target FILE) — and the original `/usr/bin/yq/yq` "Not a directory" crash — was never exercised.

- **prepare.yml**: seed a stale `/usr/bin/yq` FILE (the pre-existing-binary fixture that reproduced the crash).
- **converge.yml**: add a `yq` entry using the full-file-path convention.
- **verify.yml**: assert `/usr/bin/yq` is a regular file, no `/usr/bin/yq/yq`, yq reinstalled over the stale seed (`v4.44.1`), and directory-convention bins still land at `bin_dir/bin_name`.
- **molecule.yml**: add `verify` to the test sequence.

Validated locally end-to-end (prepare → converge → verify, `failed=0`) against a privileged `geerlingguy/docker-ubuntu2404-ansible` container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)