### PR TITLE
ci: run on dagger-labda instead of dagger-labul

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,5 +22,5 @@ jobs:
       release-message: "${{ github.event.inputs.release-message }}"
       environment-name: k8s
       archive-kind: tar.gz
-      runs-on: dagger-labul
+      runs-on: dagger-labda
       continue-error: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint yaml files
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-yaml-lint.yaml@golang-1.24.0
     with:
-      runs-on: dagger-labul
+      runs-on: dagger-labda
       environment-name: k8s
       continue-error: true
       yamllint-version: 1
@@ -29,7 +29,7 @@ jobs:
     name: Lint ansible code
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ansible-lint.yaml@golang-1.24.0
     with:
-      runs-on: dagger-labul
+      runs-on: dagger-labda
       environment-name: k8s
       continue-error: true
       ansible-image: eu.gcr.io/stuttgart-things/sthings-ansible:10.3.0
@@ -40,7 +40,7 @@ jobs:
     name: Test ansible code w/ molecule
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-moluecule-test.yaml@golang-1.24.0
     with:
-      runs-on: dagger-labul
+      runs-on: dagger-labda
       environment-name: k8s
       scenario-names: "['default']"
     # needs: ansible-lint


### PR DESCRIPTION
`dagger-labul` resolves to a single machine (`shuffle`), and it has been **offline all day**. Jobs pinned to it neither fail nor time out — they sit in `queued` indefinitely, so nothing signals that anything is wrong. In a sibling repo two releases stacked up unnoticed for hours that way.

`dagger-labda` carries two runners (`sthings-orga-runner-1/-2`), so one machine being unavailable no longer blocks everything.

## Scope

| file | line(s) | job |
|---|---|---|
| `validate.yml` | 21, 32, 43 | yaml lint, ansible lint, molecule |
| `release.yaml` | 25 | release-ansible |

`validate.yml` is the urgent one: **all three** of its jobs were pinned, so every PR in this repo currently stalls with no visible reason.

The value is passed straight through to the reusable workflows in `github-workflow-templates`, so this is a pure input change — nothing about how the jobs run changes.

## Why this repo and not everything

Only jobs with **no lab affinity** should move. These are linting, molecule (docker-based) and a GitHub release — none of them touch LabUL infrastructure. By contrast the packer/ansible workflows in the `stuttgart-things` monorepo pick their runner *from the target lab* on purpose (`*/labda/*` → `dagger-labda`, else `dagger-labul`), because provisioning into LabUL needs a runner inside LabUL. Those were deliberately left alone.

Refs stuttgart-things/sops-secrets-operator#85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo