### PR TITLE
ci: pull the ansible-lint image from ghcr instead of eu.gcr.io

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,7 +32,12 @@ jobs:
       runs-on: dagger-labda
       environment-name: k8s
       continue-error: true
-      ansible-image: eu.gcr.io/stuttgart-things/sthings-ansible:10.3.0
+      # ghcr, not eu.gcr.io: the Google Artifact Registry copy answers
+      # "Unauthenticated request" to every runner, so the job container never
+      # started and ansible-lint silently did not run — masked by
+      # continue-error below. 14.0.0 rather than a 10.3.0 equivalent because
+      # ghcr only carries the 14.x line, which is what the fleet runs today.
+      ansible-image: ghcr.io/stuttgart-things/sthings-ansible:14.0.0
       playbook: tests/test.yml
     needs: yaml-lint
 


### PR DESCRIPTION
**ansible-lint has not actually run in this repo since at least 2026-07-14.**

Its job container comes from `eu.gcr.io`, which answers every pull with:

```
Error response from daemon: error from registry: Unauthenticated request.
Unauthenticated requests do not have permission
"artifactregistry.repositories.downloadArtifacts" on resource
"projects/stuttgart-things/locations/europe/repositories/eu.gcr.io"
```

The container never starts, `continue-error: true` swallows the failure, and the workflow reports **success**. Nothing signals that the linting step is a no-op.

Verified this is not a runner problem — the job fails identically on both:

| branch | date | job | runner |
|---|---|---|---|
| `main` | 2026-07-14 | failure | `shuffle` (labul) |
| `main` | 2026-07-15 | failure | `shuffle` (labul) |
| `main` | 2026-07-15 | failure | `shuffle` (labul) |
| `ci/runner-dagger-labda` | 2026-07-21 | failure | `sthings-orga-runner-1` (labda) |

## Why 14.0.0 and not a 10.3.0 equivalent

ghcr carries no `10.3.0`. The published line is `13.5.0-test`, `14.0.0`, `14.0.0-test`, `latest`. **14.0.0 is what the fleet runs today** — the `ansible-run-defaults` EnvironmentConfig on the reference cluster pins `14.0.0-test` — so this follows the maintained line rather than guessing. Confirmed anonymously pullable (`HTTP 200` on the manifest).

## Expect findings

A lint that has been dead for a week, restarted on a much newer ansible-lint, is unlikely to come back clean. **`continue-error: true` is deliberately left in place** so that does not block PRs — but it should come off once the findings are dealt with, otherwise this step can go quiet again exactly the same way.

## Not in this PR

The same registry is referenced elsewhere and each needs its own version decision, not a find-and-replace:

| repo | image | ghcr status |
|---|---|---|
| `create-send-webhook`, `manage-proxmox-resources` | `sthings-ansible:9.3.0-1` | same situation as here → 14.0.0 |
| `install-configure-vault` | `sthings-ansible:10.3.0` | same situation as here → 14.0.0 |
| `github-workflow-templates` (call-minio-sync) | `sthings-mc-rclone:2024-05-14` | **no ghcr repository at all** |
| `stageTime-server` | `sthings-polaris:8.5.4-3.14.0` | ghcr has only `1.23` — different lineage, needs a call |

Doing this one first so the ansible-lint outcome on 14.0.0 is known before the same swap is rolled out to the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVxNQhoVf9HARnDRfPTbo